### PR TITLE
V1.1.2 : délimiteur de colonnes, utilisation de "enum"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# liste-prenoms-nouveaux-nes 1.1.1
+# liste-prenoms-nouveaux-nes 1.1.2
 Spécification de la liste annuelle des prénoms des nouveaux-nés déclarés à l'état-civil.
 
 La liste annuelle des prénoms des nouveaux-nés est un jeu de données simple et très apprécié du public. Il consiste en une liste de prénoms avec l'occurrence de chacun pour une année donnée. Les prénoms listés correspondent au premier prénom donné dans chaque acte de naissance de l'état-civil.
@@ -43,6 +43,9 @@ https://github.com/CharlesNepote/liste-prenoms-nouveaux-nes/blob/1.1/prenom-sche
 * Lorsqu'une nouvelle version est prête on la tague en veillant à ce que le tag soit cohérent avec le champ "uri" du fichier JSON.
 
 ## Historique
+* 2018-05-16 : **[v1.1.2](https://github.com/CharlesNepote/liste-prenoms-nouveaux-nes/tree/v1.1.2)**
+  * spécification du délimiteur de colonnes CSV ","
+  * utilisation du type "enum" à la place de "pattern"
 * 2018-04-12 : **[v.1.1.1](https://github.com/CharlesNepote/liste-prenoms-nouveaux-nes/tree/v1.1.1)**
   * version rétro-compatible avec la 1.1, sans aucun impact sur les données
   * changement de la regex de contrôle des prénoms pour accepter O'brian et pas seulement O'Brian

--- a/goodtables-checks.json
+++ b/goodtables-checks.json
@@ -1,0 +1,16 @@
+{
+    "$schema": "https://git.opendatafrance.net/validata/goodtables-checks-schema/raw/v0.2/goodtables_checks_schema.json",
+    "title": "Validations personnalisées en complément du schéma SCDL Prénoms",
+    "author": "Christophe Benz, Jailbreak",
+    "version": "1.1.2",
+    "created": "2018-09-26",
+    "homepage": "https://git.opendatafrance.net/scdl/prenoms",
+    "pre_checks": [
+        {
+            "name": "column-delimiter",
+            "params": {
+                "delimiter": ","
+            }
+        }
+    ]
+}

--- a/prenom-schema.json
+++ b/prenom-schema.json
@@ -39,7 +39,7 @@
       "description": "Sexe correspondant au prénom : M ou F ou I, respectivement pour masculin, féminin ou intersexué/indéterminé. L'information est importante car certains prénoms sont aussi bien masculins que féminin, comme Camille. \"I\" signale un genre spécifiquement intersexué ou indéterminé ; il ne mentionne pas un sexe inconnu. \"I\" n'est théoriquement pas encore utilisé en France mais plusieurs pays on créé un tel statut et de nombreux éléments suggèrent une évolution prochaine du droit en France (affaires judiciaires, recommandations d'experts juridiques, demandes des associations, etc.).",
       "constraints": {
         "required": true,
-        "pattern": "^(M|F|I)$"
+        "enum": ["M", "F", "I"]
       },
       "examples": "F"
     },

--- a/prenom-schema.json
+++ b/prenom-schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://frictionlessdata.io/schemas/table-schema.json",
   "title": "Spécification de la liste annuelle des prénoms des nouveaux-nés déclarés à l'état-civil",
-  "author": "Charles Nepote &lt;charles.nepote@fing.org&gt;",
+  "author": "Charles Nepote <charles.nepote@fing.org>",
   "contributor": "Simon Chignard, Bernadette Kessler, Christian Quest, Christophe Benz",
   "version": "1.1.2",
   "created": "2018-04-12",

--- a/prenom-schema.json
+++ b/prenom-schema.json
@@ -2,13 +2,13 @@
   "$schema": "https://frictionlessdata.io/schemas/table-schema.json",
   "title": "Spécification de la liste annuelle des prénoms des nouveaux-nés déclarés à l'état-civil",
   "author": "Charles Nepote &lt;charles.nepote@fing.org&gt;",
-  "contributor": "Simon Chignard, Bernadette Kessler, Christian Quest",
-  "version": "1.1.1",
+  "contributor": "Simon Chignard, Bernadette Kessler, Christian Quest, Christophe Benz",
+  "version": "1.1.2",
   "created": "2018-04-12",
   "description": "La liste annuelle des prénoms des nouveaux-nés est un jeu de données simple et très apprécié du public. Il consiste en une liste de prénoms déclarés à l'état-civil de la commune de naissance, avec l'occurrence de chacun pour une année donnée. Les prénoms listés correspondent au premier prénom donné dans chaque acte de naissance.\n\nCe schéma décrit le détail de chaque champ. Pour chacun, nous fournissons également l'expression rationnelle informatique (ou \"regexp\") qui permet de contrôler le contenu du champ.\n\n",
   "homepage": "https://github.com/CharlesNepote/liste-prenoms-nouveaux-nes",
-  "uri": "https://github.com/CharlesNepote/liste-prenoms-nouveaux-nes/blob/v1.1.1/prenom-schema.json",
-  "previous": "https://github.com/CharlesNepote/liste-prenoms-nouveaux-nes/blob/v1.1/prenom-schema.json",
+  "uri": "https://github.com/CharlesNepote/liste-prenoms-nouveaux-nes/blob/v1.1.2/prenom-schema.json",
+  "previous": "https://github.com/CharlesNepote/liste-prenoms-nouveaux-nes/blob/v1.1.1/prenom-schema.json",
   "example": "https://gist.githubusercontent.com/CharlesNepote/48a73b05762d0e49bcc26d5ea5265a75/raw/1fa1a085a793e6925991b0dc6a07d653d3726506/prenom-nouveaux-nes.exemple.1.1.csv",
   "fields": [
     {

--- a/prenom-schema.json
+++ b/prenom-schema.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://frictionlessdata.io/schemas/table-schema.json",
   "title": "Spécification de la liste annuelle des prénoms des nouveaux-nés déclarés à l'état-civil",
   "author": "Charles Nepote &lt;charles.nepote@fing.org&gt;",
   "contributor": "Simon Chignard, Bernadette Kessler, Christian Quest",


### PR DESCRIPTION
Bonjour @CharlesNepote 

Voici une suggestion d'amélioration du schéma :

* spécification du délimiteur de colonnes CSV ","
  * utilise un nouveau fichier `goodtables-checks.json` pour l'instant séparé, utilisé par Validata, mais a terme sera proposé à l'inclusion dans le table-schema
* utilisation du type "enum" à la place de "pattern"
  * ne change rien au niveau des données

Et quelques détails comme éviter d'utiliser des caractères "échappés" en HTML comme `&lt;`.