### PR TITLE
Suppression contrainte pour champ ANNEE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.5
+
+* Suppression d'une contrainte non supportée dans le champ `ANNEE`
+
 ## 1.1.4
 
 * fusion de la documentation du schéma à partir des fichiers `CONTEXT.md` et `SEE_ALSO.md` dans `README.md`

--- a/schema.json
+++ b/schema.json
@@ -139,8 +139,7 @@
       "description": "Année de relevé, sur quatre chiffres, au format AAAA.",
       "type": "year",
       "constraints": {
-        "required": true,
-        "pattern": "^[1-2]\\d\\d\\d$"
+        "required": true
       },
       "examples": "2016"
     }

--- a/schema.json
+++ b/schema.json
@@ -35,8 +35,8 @@
     }
   ],
   "created": "2018-04-12",
-  "lastModified": "2019-07-31",
-  "version": "1.1.4",
+  "lastModified": "2020-05-18",
+  "version": "1.1.5",
   "contributors": [
     {
       "title": "Charles Nepote",

--- a/schema.md
+++ b/schema.md
@@ -5,9 +5,9 @@ Spécification du modèle de données relatif aux prénoms des nouveaux-nés dé
 - nom : `prenoms`
 - page d'accueil : https://github.com/CharlesNepote/liste-prenoms-nouveaux-nes
 - URL du schéma : https://github.com/CharlesNepote/liste-prenoms-nouveaux-nes/raw/v1.1.4/schema.json
-- version : `1.1.4`
+- version : `1.1.5`
 - date de création : 2018-04-12
-- date de dernière modification : 2019-07-31
+- date de dernière modification : 2020-05-18
 - concerne le pays : FR
 - valeurs manquantes représentées par : `[""]`
 - contributeurs :
@@ -78,4 +78,3 @@ Ce modèle de données repose sur les 6 champs suivants correspondant aux colonn
 - description : Année de relevé, sur quatre chiffres, au format AAAA.
 - type : année
 - valeur obligatoire
-- motif : `^[1-2]\d\d\d$`


### PR DESCRIPTION
En validant le schéma avec la dernière version de TableSchema, on obtient l'erreur suivante :

> [ValidationError("field ANNEE: built-in pattern constraint can't be applied to year type field")]

En effet, le [champ `year`](https://specs.frictionlessdata.io/table-schema/#year) ne supporte pas de `pattern`.

Cette PR supprime cette contrainte non reconnue et publie une nouvelle version.